### PR TITLE
Load suggestions after main chart

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -127,20 +127,20 @@ const PreviewRenderer = ({
         'lnsSuggestionPanel__chartWrapper--withLabel': withLabel,
       })}
     >
-      {!isCurrentVis &&
-        (expression !== localParams.expression ||
-          !isEqual(searchContext, localParams.searchContext)) && (
-          <EuiProgress size="xs" color="accent" position="absolute" />
-        )}
+      {(expression !== localParams.expression ||
+        !isEqual(searchContext, localParams.searchContext) ||
+        localParams.searchSessionId !== searchSessionId) && (
+        <EuiProgress size="xs" color="accent" position="absolute" />
+      )}
       {!expression || hasError ? (
         onErrorMessage
       ) : (
         <ExpressionRendererComponent
           className="lnsSuggestionPanel__expressionRenderer"
           padding="s"
-          expression={isCurrentVis ? expression : localParams.expression}
-          searchContext={isCurrentVis ? searchContext : localParams.searchContext}
-          searchSessionId={isCurrentVis ? searchSessionId : localParams.searchSessionId}
+          expression={localParams.expression}
+          searchContext={localParams.searchContext}
+          searchSessionId={localParams.searchSessionId}
           renderError={() => {
             return onErrorMessage;
           }}
@@ -312,7 +312,7 @@ export function SuggestionPanel({
             frame
           )
         : undefined;
-        
+
     return {
       suggestions: newSuggestions,
       currentStateExpression: newStateExpression,
@@ -336,6 +336,17 @@ export function SuggestionPanel({
 
   const sessionIdRef = useRef<string>(searchSessionId);
   sessionIdRef.current = searchSessionId;
+
+  const suggestionsRef = useRef(suggestions);
+  suggestionsRef.current = suggestions;
+  const [localSuggestions, setLocalSuggestions] = useState<typeof suggestions>([]);
+
+  useEffect(() => {
+    if (frame.activeData && !isEqual(sortBy(localSuggestions), sortBy(suggestionsRef.current))) {
+      setLocalSuggestions(suggestionsRef.current);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [frame.activeData]);
 
   const [lastSelectedSuggestion, setLastSelectedSuggestion] = useState<number>(-1);
 
@@ -431,7 +442,7 @@ export function SuggestionPanel({
             />
           )}
           {!hideSuggestions &&
-            suggestions.map((suggestion, index) => {
+            localSuggestions.map((suggestion, index) => {
               return (
                 <SuggestionPreview
                   preview={{

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -342,10 +342,9 @@ export function SuggestionPanel({
   const [localSuggestions, setLocalSuggestions] = useState<typeof suggestions>([]);
 
   useEffect(() => {
-    if (frame.activeData && !isEqual(sortBy(localSuggestions), sortBy(suggestionsRef.current))) {
+    if (frame.activeData) {
       setLocalSuggestions(suggestionsRef.current);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [frame.activeData]);
 
   const [lastSelectedSuggestion, setLastSelectedSuggestion] = useState<number>(-1);


### PR DESCRIPTION
This seems to work fairly well. Changes:
* Remove the special handling for `currentVis` - this shouldn't be necessary
* Also check for the search session id to show/not show the loading spinner (it changes on refresh)
* Also delay the suggestions array, otherwise we are might trigger too early in case the number of suggestions panels change
 
Testing advice: Delay requests by 2s in the dev tools, that way you can clearly see when requests are scheduled.